### PR TITLE
Update bindgen version to 0.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "~0.40"
+bindgen = "~0.53"


### PR DESCRIPTION
`bindgen v0.40` depends on old version of `clang-sys` v.0.22.0. Many other crates depend on new version of `clang-sys`. However `clang-sys` is a native library and can't be linked twice with different versions. That's why current version of `blkid-sys` can't be used in most modern projects. 

I suggest to update `bindgen` in `blkid-sys` to v.0.53.

