### PR TITLE
Update version of `bindgen` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "~0.53"
+bindgen = "~0.58"

--- a/build.rs
+++ b/build.rs
@@ -7,12 +7,13 @@ fn main() {
     println!("cargo:rustc-link-lib=blkid");
 
     let bindings = bindgen::Builder::default()
-    .header("wrapper.h")
-    .rustfmt_bindings(false)
-    .generate()
-    .expect("Unable to generate bindings");
+        .header("wrapper.h")
+        .rustfmt_bindings(false)
+        .generate()
+        .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings.write_to_file(out_path.join("bindings.rs"))
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::redundant_static_lifetimes)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
* Use `bindgen` version `0.58` instead of `0.53`
* Format code by `cargofmt`
* Susspend clippy warning