### PR TITLE
Update `bindgen` to fix build with clang/LLVM 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "~0.58"
+bindgen = "~0.65"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .rustfmt_bindings(false)
+        .formatter(bindgen::Formatter::None)
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
For more details see https://github.com/rust-lang/rust-bindgen/issues/2488

Closes #3 